### PR TITLE
Close #2 - update Bevy version to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "ezinput"
 path = "src/lib.rs"
 
 [dependencies]
-bevy = { version = "0.6", features = ["serialize", "render", "x11", "bevy_gilrs"], default-features = false }
+bevy = { version = "0.7", features = ["serialize", "render", "x11", "bevy_gilrs"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 strum_macros = "0.24"
 strum = { version = "0.24", features = ["derive"] }


### PR DESCRIPTION
Looks like it works just like that - no code changes required.

I did not change the crate's version - that's your job to decide (e.g. - should the macro crate's version change too?)